### PR TITLE
Rename oauth2_proxy oauth2-proxy and update to 7.4.0

### DIFF
--- a/oauth2-proxy.cfg.example
+++ b/oauth2-proxy.cfg.example
@@ -1,0 +1,104 @@
+## OAuth2 Proxy Config File
+## https://github.com/oauth2-proxy/oauth2-proxy
+
+## <addr>:<port> to listen on for HTTP/HTTPS clients
+# http_address = "127.0.0.1:4180"
+# https_address = ":443"
+
+## Are we running behind a reverse proxy? Will not accept headers like X-Real-Ip unless this is set.
+# reverse_proxy = true
+
+## TLS Settings
+# tls_cert_file = ""
+# tls_key_file = ""
+
+## the OAuth Redirect URL.
+# defaults to the "https://" + requested host header + "/oauth2/callback"
+# redirect_url = "https://internalapp.yourcompany.com/oauth2/callback"
+
+## the http url(s) of the upstream endpoint. If multiple, routing is based on path
+# upstreams = [
+#     "http://127.0.0.1:8080/"
+# ]
+
+## Logging configuration
+#logging_filename = ""
+#logging_max_size = 100
+#logging_max_age = 7
+#logging_local_time = true
+#logging_compress = false
+#standard_logging = true
+#standard_logging_format = "[{{.Timestamp}}] [{{.File}}] {{.Message}}"
+#request_logging = true
+#request_logging_format = "{{.Client}} - {{.Username}} [{{.Timestamp}}] {{.Host}} {{.RequestMethod}} {{.Upstream}} {{.RequestURI}} {{.Protocol}} {{.UserAgent}} {{.StatusCode}} {{.ResponseSize}} {{.RequestDuration}}"
+#auth_logging = true
+#auth_logging_format = "{{.Client}} - {{.Username}} [{{.Timestamp}}] [{{.Status}}] {{.Message}}"
+
+## pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream
+# pass_basic_auth = true
+# pass_user_headers = true
+## pass the request Host Header to upstream
+## when disabled the upstream Host is used as the Host Header
+# pass_host_header = true
+
+## Email Domains to allow authentication for (this authorizes any email on this domain)
+## for more granular authorization use `authenticated_emails_file`
+## To authorize any email addresses use "*"
+# email_domains = [
+#     "yourcompany.com"
+# ]
+
+## The OAuth Client ID, Secret
+# client_id = "123456.apps.googleusercontent.com"
+# client_secret = ""
+
+## Pass OAuth Access token to upstream via "X-Forwarded-Access-Token"
+# pass_access_token = false
+
+## Authenticated Email Addresses File (one email per line)
+# authenticated_emails_file = ""
+
+## Htpasswd File (optional)
+## Additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -B" for bcrypt encryption
+## enabling exposes a username/login signin form
+# htpasswd_file = ""
+
+## bypass authentication for requests that match the method & path. Format: method=path_regex OR path_regex alone for all methods
+# skip_auth_routes = [
+#   "GET=^/probe",
+#   "^/metrics"
+# ]
+
+## mark paths as API routes to get HTTP Status code 401 instead of redirect to login page
+# api_routes = [
+#   "^/api
+# ]
+
+## Templates
+## optional directory with custom sign_in.html and error.html
+# custom_templates_dir = ""
+
+## skip SSL checking for HTTPS requests
+# ssl_insecure_skip_verify = false
+
+
+## Cookie Settings
+## Name     - the cookie name
+## Secret   - the seed string for secure cookies; should be 16, 24, or 32 bytes
+##            for use with an AES cipher when cookie_refresh or pass_access_token
+##            is set
+## Domain   - (optional) cookie domain to force cookies to (ie: .yourcompany.com)
+## Expire   - (duration) expire timeframe for cookie
+## Refresh  - (duration) refresh the cookie when duration has elapsed after cookie was initially set.
+##            Should be less than cookie_expire; set to 0 to disable.
+##            On refresh, OAuth token is re-validated.
+##            (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
+## Secure   - secure cookies are only sent by the browser of a HTTPS connection (recommended)
+## HttpOnly - httponly cookies are not readable by javascript (recommended)
+# cookie_name = "_oauth2_proxy"
+# cookie_secret = ""
+# cookie_domains = ""
+# cookie_expire = "168h"
+# cookie_refresh = ""
+# cookie_secure = true
+# cookie_httponly = true

--- a/oauth2-proxy.service.example
+++ b/oauth2-proxy.service.example
@@ -1,0 +1,22 @@
+# Systemd service file for oauth2-proxy daemon
+#
+# Date: Feb 9, 2016
+# Author: Srdjan Grubor <sgnn7@sgnn7.org>
+
+[Unit]
+Description=oauth2-proxy daemon service
+After=syslog.target network.target
+
+[Service]
+# www-data group and user need to be created before using these lines
+User=www-data
+Group=www-data
+
+ExecStart=/usr/bin/oauth2-proxy --config=/etc/oauth2-proxy.cfg
+ExecReload=/bin/kill -HUP $MAINPID
+
+KillMode=process
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/oauth2-proxy.spec
+++ b/oauth2-proxy.spec
@@ -1,17 +1,17 @@
-# Copyright 2017 Adrien Vergé
+# Copyright 2017-2022 Adrien Vergé
 
 %define debug_package %{nil}
 
 Name:           oauth2-proxy
-Version:        2.2
+Version:        7.4.0
 Release:        1%{?dist}
 Summary:        A reverse proxy that provides authentication with Google, Github or other provider
 License:        MIT
-URL:            https://github.com/bitly/oauth2_proxy
-Source0:        oauth2_proxy-v%{version}.tar.gz
+URL:            https://github.com/oauth2-proxy/oauth2-proxy
+Source0:        oauth2-proxy-v7.4.0.linux-amd64.tar.gz
+Source1:        oauth2-proxy.cfg.example
+Source2:        oauth2-proxy.service.example
 
-BuildRequires: git
-BuildRequires: golang
 BuildRequires: systemd
 
 Requires(pre): shadow-utils
@@ -24,22 +24,16 @@ Providers (Google, GitHub, and others) to validate accounts by email, domain or
 group.
 
 %prep
-%setup -q -n oauth2_proxy-%{version}
+%setup -q -n oauth2-proxy-v%{version}.linux-amd64
 
 %build
-export GOPATH=$(pwd)/_build
-export GOBIN=$(pwd)/_build/bin
-go get .
-go build -o oauth2_proxy .
-sed -i 's|/usr/local/bin/oauth2_proxy|/usr/bin/oauth2_proxy|g' \
-  contrib/oauth2_proxy.service.example
+echo "For simplicity I use the official pre-built binary from the GitHub repo"
+sed -i 's|/usr/local/bin/oauth2-proxy|/usr/bin/oauth2-proxy|g' %{SOURCE2}
 
 %install
-install -D -p -m 755 oauth2_proxy %{buildroot}%{_bindir}/oauth2_proxy
-install -D -p -m 644 contrib/oauth2_proxy.cfg.example \
-  %{buildroot}%{_sysconfdir}/oauth2_proxy.cfg
-install -D -p -m 644 contrib/oauth2_proxy.service.example \
-  %{buildroot}%{_unitdir}/oauth2_proxy.service
+install -D -p -m 755 oauth2-proxy %{buildroot}%{_bindir}/oauth2-proxy
+install -D -p -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/oauth2-proxy.cfg
+install -D -p -m 644 %{SOURCE2} %{buildroot}%{_unitdir}/oauth2-proxy.service
 
 %pre
 getent group www-data >/dev/null || groupadd -r www-data
@@ -47,22 +41,24 @@ getent passwd www-data >/dev/null || \
   useradd -r -g www-data -s /sbin/nologin www-data
 
 %post
-%systemd_post oauth2_proxy.service
+%systemd_post oauth2-proxy.service
 
 %preun
-%systemd_preun oauth2_proxy.service
+%systemd_preun oauth2-proxy.service
 
 %postun
-%systemd_postun_with_restart oauth2_proxy.service
+%systemd_postun_with_restart oauth2-proxy.service
 
 %files
 %defattr(-,root,root,-)
-%doc LICENSE README.md
-%{_bindir}/oauth2_proxy
-%config(noreplace) %{_sysconfdir}/oauth2_proxy.cfg
-%{_unitdir}/oauth2_proxy.service
+%{_bindir}/oauth2-proxy
+%config(noreplace) %{_sysconfdir}/oauth2-proxy.cfg
+%{_unitdir}/oauth2-proxy.service
 
 %changelog
+* Mon Nov 14 2022 Adrien Vergé - 7.4.0-1
+- Update to latest upstream version
+
 * Wed Sep 6 2017 Adrien Vergé - 2.2-1
 - Update to latest upstream version
 


### PR DESCRIPTION
The rename reflects the change upstream.

Note: this commit was created 2 years later, from the SRPM submitted on COPR at 2022-11-14 18:00 CET.