### PR TITLE
Update to oauth2-proxy 7.7.1

### DIFF
--- a/oauth2-proxy.cfg.example
+++ b/oauth2-proxy.cfg.example
@@ -52,6 +52,10 @@
 # client_id = "123456.apps.googleusercontent.com"
 # client_secret = ""
 
+## Scopes Added to the request
+## It has the same behavior as the --scope flag
+# scope = "openid email profile"
+
 ## Pass OAuth Access token to upstream via "X-Forwarded-Access-Token"
 # pass_access_token = false
 
@@ -71,7 +75,7 @@
 
 ## mark paths as API routes to get HTTP Status code 401 instead of redirect to login page
 # api_routes = [
-#   "^/api
+#   "^/api"
 # ]
 
 ## Templates

--- a/oauth2-proxy.service.example
+++ b/oauth2-proxy.service.example
@@ -1,22 +1,33 @@
-# Systemd service file for oauth2-proxy daemon
-#
-# Date: Feb 9, 2016
-# Author: Srdjan Grubor <sgnn7@sgnn7.org>
-
 [Unit]
 Description=oauth2-proxy daemon service
-After=syslog.target network.target
+After=network.target network-online.target nss-lookup.target basic.target
+Wants=network-online.target nss-lookup.target
+StartLimitIntervalSec=30
+StartLimitBurst=3
 
 [Service]
-# www-data group and user need to be created before using these lines
-User=www-data
-Group=www-data
-
-ExecStart=/usr/bin/oauth2-proxy --config=/etc/oauth2-proxy.cfg
+User=oauth2-proxy
+Group=oauth2-proxy
+Restart=on-failure
+RestartSec=30
+WorkingDirectory=/etc/oauth2-proxy
+ExecStart=/usr/bin/oauth2-proxy --config=/etc/oauth2-proxy/oauth2-proxy.cfg
 ExecReload=/bin/kill -HUP $MAINPID
-
-KillMode=process
-Restart=always
+LimitNOFILE=65535
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=yes
+RestrictNamespaces=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+PrivateTmp=true
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/oauth2-proxy.spec
+++ b/oauth2-proxy.spec
@@ -1,14 +1,14 @@
-# Copyright 2017-2022 Adrien Vergé
+# Copyright 2017-2024 Adrien Vergé
 
 %define debug_package %{nil}
 
 Name:           oauth2-proxy
-Version:        7.4.0
+Version:        7.7.1
 Release:        1%{?dist}
 Summary:        A reverse proxy that provides authentication with Google, Github or other provider
 License:        MIT
 URL:            https://github.com/oauth2-proxy/oauth2-proxy
-Source0:        oauth2-proxy-v7.4.0.linux-amd64.tar.gz
+Source0:        oauth2-proxy-v7.7.1.linux-amd64.tar.gz
 Source1:        oauth2-proxy.cfg.example
 Source2:        oauth2-proxy.service.example
 
@@ -28,7 +28,6 @@ group.
 
 %build
 echo "For simplicity I use the official pre-built binary from the GitHub repo"
-sed -i 's|/usr/local/bin/oauth2-proxy|/usr/bin/oauth2-proxy|g' %{SOURCE2}
 
 %install
 install -D -p -m 755 oauth2-proxy %{buildroot}%{_bindir}/oauth2-proxy
@@ -36,9 +35,9 @@ install -D -p -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/oauth2-proxy.cfg
 install -D -p -m 644 %{SOURCE2} %{buildroot}%{_unitdir}/oauth2-proxy.service
 
 %pre
-getent group www-data >/dev/null || groupadd -r www-data
-getent passwd www-data >/dev/null || \
-  useradd -r -g www-data -s /sbin/nologin www-data
+getent group oauth2-proxy >/dev/null || groupadd -r oauth2-proxy
+getent passwd oauth2-proxy >/dev/null || \
+  useradd -r -g oauth2-proxy -s /sbin/nologin oauth2-proxy
 
 %post
 %systemd_post oauth2-proxy.service
@@ -56,6 +55,9 @@ getent passwd www-data >/dev/null || \
 %{_unitdir}/oauth2-proxy.service
 
 %changelog
+* Mon Nov 18 2024 Adrien Vergé - 7.7.1-1
+- Update to latest upstream version
+
 * Mon Nov 14 2022 Adrien Vergé - 7.4.0-1
 - Update to latest upstream version
 

--- a/oauth2-proxy.spec
+++ b/oauth2-proxy.spec
@@ -29,6 +29,21 @@ group.
 %build
 echo "For simplicity I use the official pre-built binary from the GitHub repo"
 
+# Avoid the second screen "By continuing, Google will share your name…" every
+# time. I found this solution after reading https://stackoverflow.com/a/48771341
+# and https://github.com/oauth2-proxy/oauth2-proxy/pull/444
+patch %{SOURCE2} <<'PATCH'
+@@ -11,7 +11,7 @@ Group=oauth2-proxy
+ Restart=on-failure
+ RestartSec=30
+ WorkingDirectory=/etc/oauth2-proxy
+-ExecStart=/usr/bin/oauth2-proxy --config=/etc/oauth2-proxy/oauth2-proxy.cfg
++ExecStart=/usr/bin/oauth2-proxy --config=/etc/oauth2-proxy/oauth2-proxy.cfg --prompt=select_account
+ ExecReload=/bin/kill -HUP $MAINPID
+ LimitNOFILE=65535
+ NoNewPrivileges=true
+PATCH
+
 %install
 install -D -p -m 755 oauth2-proxy %{buildroot}%{_bindir}/oauth2-proxy
 install -D -p -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/oauth2-proxy.cfg


### PR DESCRIPTION
#### Update to oauth2-proxy 7.7.1

---

#### Pass --prompt=select_account to avoid 2nd Google OAuth screen

Avoid the second screen "By continuing, Google will share your name…"
every time. I found this solution after reading
https://stackoverflow.com/a/48771341 and
https://github.com/oauth2-proxy/oauth2-proxy/pull/444